### PR TITLE
Fix CydiaSubstrate usage with latest TAPI

### DIFF
--- a/CydiaSubstrate.framework/CydiaSubstrate.tbd
+++ b/CydiaSubstrate.framework/CydiaSubstrate.tbd
@@ -1,12 +1,13 @@
 ---
-archs:           [ armv7, armv7s, arm64, arm64e, i386, x86_64 ]
+archs:           [ armv7, armv7s, arm64, arm64e ]
 platform:        ios
 install-name:    '@rpath/CydiaSubstrate.framework/CydiaSubstrate'
 current-version: 0.0.0
 compatibility-version: 0.0.0
 exports:
-  - archs:            [ armv7, armv7s, arm64, arm64e, i386, x86_64 ]
-    symbols:          [ _MSDebug,
-                        _MSFindSymbol, _MSGetImageByName,
-                        _MSHookFunction, _MSHookMessageEx ]
+  - archs:            [ armv7, armv7s, arm64, arm64e ]
+    symbols:          [ _MSCloseImage, _MSDebug, _MSFindAddress, _MSFindSymbol,
+                        _MSGetImageByName, _MSHookClassPair, _MSHookFunction,
+                        _MSHookMemory, _MSHookMessageEx, _MSImageAddress,
+                        _MSMapImage ]
 ...


### PR DESCRIPTION
Removes non-arm archs and updates provided symbols